### PR TITLE
Generate checksum files for artifacts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -89,6 +89,15 @@ cd -
 
 rm -rf ffbuild
 
+cd "${ARTIFACTS_PATH}" &&
+{
+    for bits in 512 256; do
+        ext="sha${bits}"
+        ${ext}sum --binary "${OUTPUT_FNAME}" >| "${OUTPUT_FNAME}.${ext}"
+    done ; unset -v ext bits ;
+    cd - ;
+}
+
 if [[ -n "$GITHUB_ACTIONS" ]]; then
     echo "build_name=${BUILD_NAME}" >> "$GITHUB_OUTPUT"
     echo "${OUTPUT_FNAME}" > "${ARTIFACTS_PATH}/${TARGET}-${VARIANT}${ADDINS_STR:+-}${ADDINS_STR}.txt"


### PR DESCRIPTION
This makes it much nicer for anyone using Docker to download an archive using `ADD`.

See the documentation: https://docs.docker.com/reference/dockerfile/#add---checksum

Also, anyone else who needs to verify the built file doesn't need to download then generate their own checksum.