### PR TITLE
Sums for releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,7 +282,8 @@ jobs:
           RELDATE="$(date +'%Y-%m-%d %H:%M')"
           NAME="Auto-Build $RELDATE"
           TAGNAME="autobuild-$(date +'%Y-%m-%d-%H-%M')"
-          gh release create "$TAGNAME" --target "master" --title "$NAME" artifacts/*.{zip,tar.xz}
+          cat artifacts/*.sums > SUMS
+          gh release create "$TAGNAME" --target "master" --title "$NAME" SUMS artifacts/*.{zip,tar.xz}
           echo "tag_name=${TAGNAME}" >> $GITHUB_OUTPUT
           echo "rel_date=${RELDATE}" >> $GITHUB_OUTPUT
         env:
@@ -297,6 +298,7 @@ jobs:
           TAGNAME="latest"
           gh release delete --cleanup-tag --yes "$TAGNAME" || true
           sleep 15
+          ( cd latest_artifacts && for bits in 512 384 256; do sha${bits}sum --binary --tag * ; done > .SUMS ; mv .SUMS SUMS; )
           gh release create "$TAGNAME" --target "master" --title "$NAME" latest_artifacts/*
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,9 +297,10 @@ jobs:
           NAME="Latest Auto-Build (${{ steps.create_release.outputs.rel_date }})"
           TAGNAME="latest"
           gh release delete --cleanup-tag --yes "$TAGNAME" || true
-          sleep 15
-          ( cd latest_artifacts && for bits in 512 384 256; do sha${bits}sum --binary --tag * ; done > .SUMS ; mv .SUMS SUMS; )
-          gh release create "$TAGNAME" --target "master" --title "$NAME" latest_artifacts/*
+          sleep 15 &
+          ( cd latest_artifacts && for bits in 512 384 256; do sha${bits}sum --binary --tag * ; done > ../SUMS ; ) &
+          wait
+          gh release create "$TAGNAME" --target "master" --title "$NAME" SUMS latest_artifacts/*
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Update Wiki

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,9 +296,9 @@ jobs:
           ./util/repack_latest.sh latest_artifacts artifacts/*.{zip,tar.xz}
           NAME="Latest Auto-Build (${{ steps.create_release.outputs.rel_date }})"
           TAGNAME="latest"
+          ( cd latest_artifacts && for bits in 512 384 256; do sha${bits}sum --binary --tag * ; done > ../SUMS < /dev/null ; ) &
           gh release delete --cleanup-tag --yes "$TAGNAME" || true
           sleep 15 &
-          ( cd latest_artifacts && for bits in 512 384 256; do sha${bits}sum --binary --tag * ; done > ../SUMS ; ) &
           wait
           gh release create "$TAGNAME" --target "master" --title "$NAME" SUMS latest_artifacts/*
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,7 +282,7 @@ jobs:
           RELDATE="$(date +'%Y-%m-%d %H:%M')"
           NAME="Auto-Build $RELDATE"
           TAGNAME="autobuild-$(date +'%Y-%m-%d-%H-%M')"
-          cat artifacts/*.sums > SUMS
+          cat artifacts/*.sums > SUMS < /dev/null
           gh release create "$TAGNAME" --target "master" --title "$NAME" SUMS artifacts/*.{zip,tar.xz}
           echo "tag_name=${TAGNAME}" >> $GITHUB_OUTPUT
           echo "rel_date=${RELDATE}" >> $GITHUB_OUTPUT

--- a/build.sh
+++ b/build.sh
@@ -79,8 +79,7 @@ rm -rf ffbuild
 cd "${ARTIFACTS_PATH}" &&
 (
     for bits in 512 384 256; do
-        ext="sha${bits}"
-        ${ext}sum --binary --tag "${OUTPUT_FNAME}"
+        sha${bits}sum --binary --tag "${OUTPUT_FNAME}"
     done >| "${OUTPUT_FNAME}.sums"
 )
 

--- a/build.sh
+++ b/build.sh
@@ -76,6 +76,14 @@ cd -
 
 rm -rf ffbuild
 
+cd "${ARTIFACTS_PATH}" &&
+(
+    for bits in 512 256; do
+        ext="sha${bits}"
+        ${ext}sum --binary "${OUTPUT_FNAME}" >| "${OUTPUT_FNAME}.${ext}"
+    done
+)
+
 if [[ -n "$GITHUB_ACTIONS" ]]; then
     echo "build_name=${BUILD_NAME}" >> "$GITHUB_OUTPUT"
     echo "${OUTPUT_FNAME}" > "${ARTIFACTS_PATH}/${TARGET}-${VARIANT}${ADDINS_STR:+-}${ADDINS_STR}.txt"

--- a/build.sh
+++ b/build.sh
@@ -78,10 +78,10 @@ rm -rf ffbuild
 
 cd "${ARTIFACTS_PATH}" &&
 (
-    for bits in 512 256; do
+    for bits in 512 384 256; do
         ext="sha${bits}"
-        ${ext}sum --binary "${OUTPUT_FNAME}" >| "${OUTPUT_FNAME}.${ext}"
-    done
+        ${ext}sum --binary --tag "${OUTPUT_FNAME}"
+    done >| "${OUTPUT_FNAME}.sums"
 )
 
 if [[ -n "$GITHUB_ACTIONS" ]]; then


### PR DESCRIPTION
Upstream has added `checksums.sha256` (which we hope works) but I like this better because it spreads the task of computing sums to the job runners, and provides all the sha algorithm sums in a format that's easy to grep the algorithm and/or file that you want to use from the `SUMS` file.

This is a follow up from: #69