### PR TITLE
Re-add Patches Applied section with a placeholder message

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ There are currently no MacOS builds. If you know how to add them to the workflow
 [FFmpeg#7673](https://trac.ffmpeg.org/ticket/7673)
 
 
-<!--
 ## Patches Applied
+Currently no patches have been applied to the builds
+<!--
 These patches have been applied to the builds:
 -->
 


### PR DESCRIPTION
The main yt-dlp repository's Readme refers users to `https://github.com/yt-dlp/FFmpeg-Builds#patches-applied` to learn about the custom builds. Since the section didn't exist in the Readme, this link instead just went to the repository page, giving the impression of a broken link.

This re-adds the commented-out section with a message saying there are no updates.